### PR TITLE
[fix] include required scripts

### DIFF
--- a/vbump
+++ b/vbump
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 [ -f "package.json" ] && VERSION=`node -e "console.log(require('./package').version)"` || VERSION=
-[ -z "$NPM" ] && NPM=npm
 NO_NPM=
 CHANGED=
 DRY_RUN=

--- a/vbump
+++ b/vbump
@@ -177,6 +177,10 @@ if [ -z $NO_NPM ]; then
   if [ ! -f 'package.json' ]; then
     echoc "No package.json file. Skipping 'npm publish'" "YELLOW"
   else
-    run npm publish
+    if [ -n "$NPM_CONFIG" ]; then
+      run npm publish --userconfig $NPM_CONFIG
+    else
+      run npm publish
+    fi
   fi
 fi

--- a/vbump
+++ b/vbump
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 [ -f "package.json" ] && VERSION=`node -e "console.log(require('./package').version)"` || VERSION=
+[ -z "$NPM" ] && NPM=npm
 NO_NPM=
 CHANGED=
 DRY_RUN=

--- a/vbump
+++ b/vbump
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# TODO: Use the parsed package.json script and check the git tags against it.
-#[ -f "package.json" ] && VERSION=`pkgver package.json` || VERSION=
-
-VERSION=
+[ -f "package.json" ] && VERSION=`node -e "console.log(require('./package').version)"` || VERSION=
 NO_NPM=
 CHANGED=
 DRY_RUN=
@@ -32,6 +29,59 @@ EOF
 }
 
 #
+# Setup colors
+#
+if tput setaf 1 &> /dev/null; then
+  tput sgr0
+  if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
+    RED=$(tput setaf 9)
+    ORANGE=$(tput setaf 172)
+    YELLOW=$(tput setaf 190)
+    PURPLE=$(tput setaf 141)
+    WHITE=$(tput setaf 256)
+  else
+    RED=$(tput setaf 5)
+    ORANGE=$(tput setaf 4)
+    YELLOW=$(tput setaf 2)
+    PURPLE=$(tput setaf 1)
+    WHITE=$(tput setaf 7)
+  fi
+  BOLD=$(tput bold)
+  RESET=$(tput sgr0)
+else
+  RED="\033[1;31m"
+  ORANGE="\033[1;33m"
+  YELLOW="\033[1;32m"
+  PURPLE="\033[1;35m"
+  WHITE="\033[1;37m"
+  BOLD=""
+  RESET="\033[m"
+fi
+
+#
+# echoc (msg color)
+# Echos the msg with the specified color
+#
+function echoc () {
+  msg=$1
+  color=$2
+  [ -z $color ] && color=$PURPLE || color=${!color}
+  [ ! -z $color ] || color=$PURPLE
+  echo "$color$msg$RESET"
+}
+
+#
+# run(@)
+# Runs `cmd` unless -d (i.e. DRY_RUN) is set.
+#
+function run () {
+  echoc "$*"
+  if [ -z $DRY_RUN ]; then
+    "$@"
+  fi
+}
+
+#
 # checkgit()
 # Ensures everything is up-to-date
 #
@@ -45,10 +95,6 @@ checkgit() {
     exit 1
   fi
 }
-
-# Setup colors
-source $HOME/.functions
-set_colors
 
 while getopts "v:m:hpdt" OPTION; do
   case $OPTION in
@@ -98,7 +144,9 @@ if [ -z "$COMMIT_MSG" ]; then
   COMMIT_MSG="[dist] Version bump. $VERSION"
 fi
 
+#
 # Check git remote(s)
+#
 checkgit
 
 #
@@ -122,7 +170,9 @@ if [ -z $TAG_ONLY ]; then
   run git push origin master
 fi
 
+#
 # Check for a package.json
+#
 if [ -z $NO_NPM ]; then
   if [ ! -f 'package.json' ]; then
     echoc "No package.json file. Skipping 'npm publish'" "YELLOW"


### PR DESCRIPTION
Included some of your bash scripts in .functions, not the proper way, as its far from DRY, but wanted to prevent others from running into the same stuff while you do meetings ;) Feel free to close or adjust to your likings.

edit: added --userconfig support, as I use `gnpm` to push to private registry, aliases are not available from the bash script but `NPM_CONFIG=~/.custom-npmconfig` will use the supplied config
